### PR TITLE
Add closing date tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# JS_coursera Todo Example
+
+Esta versión muestra una aplicación de **lista de tareas** más completa escrita con HTML, CSS y JavaScript.
+Las tareas se almacenan en `localStorage` y la página funciona tanto en escritorio como en móviles.
+
+## Archivos
+- `todo.html` – Estructura de la interfaz.
+- `style.css` – Estilos con Flexbox y modo oscuro.
+- `script.js` – Lógica para agregar, editar, filtrar y ordenar tareas.
+
+Desde la versión actual cada tarea incluye responsable, importancia, prioridad y una fecha promesa. Al completarla se guarda automáticamente la fecha de cierre. La interfaz muestra dos gráficas con el estado y la prioridad de todas las tareas.
+
+## Uso
+Abre `todo.html` en tu navegador. Podrás:
+
+- Crear tareas y asignarles categoría.
+- Marcar como completadas, editar o eliminar de forma individual o todas a la vez.
+- Deshacer la última acción.
+- Filtrar por estado o buscar por texto.
+- Ordenar por fecha, nombre o estado.
+- Alternar entre modo claro y oscuro.
+- Ver contadores de tareas totales, completadas y pendientes.
+- Registrar responsable, importancia, prioridad y fecha promesa para cada tarea.
+- Al completar una tarea se guarda la fecha de cierre y se muestra junto a la promesa.
+- Colorear las tareas segun si estan vencidas, proximas o en tiempo.
+- Visualizar graficas de pastel con el estado y la prioridad de las tareas.
+
+Las tareas se cargan automáticamente cada vez que abras la página.

--- a/script.js
+++ b/script.js
@@ -1,0 +1,299 @@
+/**
+ * script.js - Logica avanzada para la lista de tareas
+ * Permite agregar, editar, filtrar y ordenar tareas.
+ * Las tareas se guardan en localStorage y se mantiene un historial para deshacer.
+ */
+
+let tasks = JSON.parse(localStorage.getItem('tasks')) || [];
+let undoStack = [];
+let currentFilter = 'all';
+let sortBy = 'date';
+let searchText = '';
+
+// Elementos del DOM
+const taskInput = document.getElementById('taskInput');
+const categoryInput = document.getElementById('categoryInput');
+const responsibleInput = document.getElementById('responsibleInput');
+const importanceInput = document.getElementById('importanceInput');
+const priorityInput = document.getElementById('priorityInput');
+const dueDateInput = document.getElementById('dueDateInput');
+const addButton = document.getElementById('addButton');
+const taskList = document.getElementById('taskList');
+const searchInput = document.getElementById('searchInput');
+const filterButtons = document.querySelectorAll('.filter');
+const sortSelect = document.getElementById('sortSelect');
+const themeToggle = document.getElementById('themeToggle');
+const undoButton = document.getElementById('undoButton');
+const clearButton = document.getElementById('clearButton');
+const totalCount = document.getElementById('totalCount');
+const completedCount = document.getElementById('completedCount');
+const pendingCount = document.getElementById('pendingCount');
+const statusCtx = document.getElementById('statusChart');
+const priorityCtx = document.getElementById('priorityChart');
+
+let statusChart;
+let priorityChart;
+
+/** Guarda las tareas en localStorage */
+function saveTasks() {
+  localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+/** Guarda la preferencia de tema */
+function saveTheme() {
+  localStorage.setItem('darkMode', document.body.classList.contains('dark'));
+}
+
+/** Crea el elemento visual para una tarea */
+function createTaskElement(task) {
+  const li = document.createElement('li');
+  li.dataset.id = task.id;
+  if (task.completed) {
+    li.classList.add('completed');
+  } else {
+    const diff = task.dueDate ? (new Date(task.dueDate) - new Date()) / (1000 * 60 * 60 * 24) : Infinity;
+    if (diff < 0) li.classList.add('overdue');
+    else if (diff <= 2) li.classList.add('due-soon');
+    else li.classList.add('on-time');
+  }
+
+  const info = document.createElement('span');
+  info.className = 'info';
+  const due = task.dueDate ? new Date(task.dueDate).toLocaleDateString() : 'N/A';
+  const closed = task.closedAt ? new Date(task.closedAt).toLocaleDateString() : '';
+  info.innerHTML = `<strong>${task.text}</strong> <small>[${task.category || 'General'}]</small> <em>${new Date(task.createdAt).toLocaleString()}</em><br>Resp: ${task.responsible || '-'} | Imp: ${task.importance || '-'} | Pri: ${task.priority || '-'} | Promesa: ${due}${closed ? ' | Cierre: ' + closed : ''}`;
+  li.appendChild(info);
+
+  const editBtn = document.createElement('button');
+  editBtn.textContent = 'Editar';
+  editBtn.addEventListener('click', () => editTask(task.id));
+
+  const completeBtn = document.createElement('button');
+  completeBtn.textContent = task.completed ? 'Deshacer' : 'Completar';
+  completeBtn.addEventListener('click', () => toggleTask(task.id));
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.textContent = 'Eliminar';
+  deleteBtn.addEventListener('click', () => removeTask(task.id));
+
+  li.append(editBtn, completeBtn, deleteBtn);
+  taskList.appendChild(li);
+}
+
+/** Muestra las tareas aplicando filtros y orden */
+function renderTasks() {
+  let filtered = tasks.filter(t => {
+    const matchFilter =
+      currentFilter === 'all' ||
+      (currentFilter === 'completed' && t.completed) ||
+      (currentFilter === 'pending' && !t.completed);
+    const matchText = t.text.toLowerCase().includes(searchText);
+    return matchFilter && matchText;
+  });
+
+  filtered.sort((a, b) => {
+    if (sortBy === 'name') return a.text.localeCompare(b.text);
+    if (sortBy === 'status') return a.completed === b.completed ? 0 : a.completed ? 1 : -1;
+    return a.createdAt - b.createdAt; // por fecha
+  });
+
+  taskList.innerHTML = '';
+  filtered.forEach(createTaskElement);
+
+  totalCount.textContent = `${tasks.length} totales`;
+  completedCount.textContent = `${tasks.filter(t => t.completed).length} completadas`;
+  pendingCount.textContent = `${tasks.filter(t => !t.completed).length} pendientes`;
+
+  updateCharts();
+}
+
+/** Actualiza las graficas de pastel */
+function updateCharts() {
+  if (!statusCtx || !priorityCtx) return;
+
+  const now = new Date();
+  const overdue = tasks.filter(t => !t.completed && t.dueDate && new Date(t.dueDate) < now).length;
+  const dueSoon = tasks.filter(t => !t.completed && t.dueDate && (new Date(t.dueDate) - now) / (1000*60*60*24) <= 2 && (new Date(t.dueDate) - now) >= 0).length;
+  const onTime = tasks.filter(t => !t.completed && (!t.dueDate || (new Date(t.dueDate) - now) / (1000*60*60*24) > 2)).length;
+  const completed = tasks.filter(t => t.completed).length;
+
+  const priorities = { Alta: 0, Media: 0, Baja: 0 };
+  tasks.forEach(t => {
+    if (t.priority && priorities[t.priority] !== undefined) {
+      priorities[t.priority]++;
+    }
+  });
+
+  if (statusChart) statusChart.destroy();
+  statusChart = new Chart(statusCtx, {
+    type: 'pie',
+    data: {
+      labels: ['Vencidas', 'Pronto', 'En tiempo', 'Completadas'],
+      datasets: [{ data: [overdue, dueSoon, onTime, completed], backgroundColor: ['#ff6666', '#ffcc66', '#66cc66', '#6699ff'] }]
+    },
+    options: { responsive: false }
+  });
+
+  if (priorityChart) priorityChart.destroy();
+  priorityChart = new Chart(priorityCtx, {
+    type: 'pie',
+    data: {
+      labels: Object.keys(priorities),
+      datasets: [{ data: Object.values(priorities), backgroundColor: ['#ff9999','#ffd699','#ffff99'] }]
+    },
+    options: { responsive: false }
+  });
+}
+
+/** Agrega una nueva tarea */
+function addTask() {
+  const text = taskInput.value.trim();
+  if (!text) return;
+  const task = {
+    id: Date.now(),
+    text,
+    category: categoryInput.value.trim(),
+    responsible: responsibleInput.value.trim(),
+    importance: importanceInput.value,
+    priority: priorityInput.value,
+    dueDate: dueDateInput.value,
+    completed: false,
+    createdAt: Date.now(),
+    closedAt: null
+  };
+  tasks.push(task);
+  saveTasks();
+  renderTasks();
+  taskInput.value = '';
+  categoryInput.value = '';
+  responsibleInput.value = '';
+  importanceInput.value = 'Alta';
+  priorityInput.value = 'Alta';
+  dueDateInput.value = '';
+}
+
+/** Cambia el estado de completada de una tarea */
+function toggleTask(id) {
+  const task = tasks.find(t => t.id === id);
+  if (!task) return;
+  undoStack.push({ action: 'toggle', id, prevCompleted: task.completed, prevClosedAt: task.closedAt });
+  task.completed = !task.completed;
+  task.closedAt = task.completed ? Date.now() : null;
+  saveTasks();
+  renderTasks();
+}
+
+/** Elimina una tarea */
+function removeTask(id) {
+  const index = tasks.findIndex(t => t.id === id);
+  if (index === -1) return;
+  const removed = tasks.splice(index, 1)[0];
+  undoStack.push({ action: 'delete', task: removed, index });
+  saveTasks();
+  renderTasks();
+}
+
+/** Edita el texto de una tarea */
+function editTask(id) {
+  const li = Array.from(taskList.children).find(el => +el.dataset.id === id);
+  const task = tasks.find(t => t.id === id);
+  if (!li || !task) return;
+
+  const input = document.createElement('input');
+  input.value = task.text;
+  li.querySelector('.info').replaceWith(input);
+  input.focus();
+
+  const saveEdit = () => {
+    const oldTask = { ...task };
+    task.text = input.value.trim();
+    const resp = prompt('Responsable', task.responsible || '');
+    if (resp !== null) task.responsible = resp.trim();
+    const imp = prompt('Importancia (Alta/Media/Baja)', task.importance || 'Alta');
+    if (imp !== null) task.importance = imp;
+    const pri = prompt('Prioridad (Alta/Media/Baja)', task.priority || 'Alta');
+    if (pri !== null) task.priority = pri;
+    const due = prompt('Fecha promesa (YYYY-MM-DD)', task.dueDate || '');
+    if (due !== null) task.dueDate = due;
+    undoStack.push({ action: 'edit', id, oldTask });
+    saveTasks();
+    renderTasks();
+  };
+
+  input.addEventListener('blur', saveEdit);
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') saveEdit();
+  });
+}
+
+/** Elimina todas las tareas */
+function clearAll() {
+  if (tasks.length === 0) return;
+  undoStack.push({ action: 'clear', tasks: [...tasks] });
+  tasks = [];
+  saveTasks();
+  renderTasks();
+}
+
+/** Deshace la ultima accion */
+function undo() {
+  const last = undoStack.pop();
+  if (!last) return;
+
+  if (last.action === 'delete') {
+    tasks.splice(last.index, 0, last.task);
+  } else if (last.action === 'toggle') {
+    const t = tasks.find(t => t.id === last.id);
+    if (t) {
+      t.completed = last.prevCompleted;
+      t.closedAt = last.prevClosedAt;
+    }
+  } else if (last.action === 'edit') {
+    const index = tasks.findIndex(t => t.id === last.id);
+    if (index !== -1) tasks[index] = last.oldTask;
+  } else if (last.action === 'clear') {
+    tasks = last.tasks;
+  }
+
+  saveTasks();
+  renderTasks();
+}
+
+/** Inicializa el tema oscuro/claro */
+function initTheme() {
+  if (localStorage.getItem('darkMode') === 'true') {
+    document.body.classList.add('dark');
+  }
+  themeToggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    saveTheme();
+  });
+}
+
+// Eventos
+addButton.addEventListener('click', addTask);
+[taskInput, categoryInput, responsibleInput, dueDateInput].forEach(input =>
+  input.addEventListener('keydown', e => e.key === 'Enter' && addTask())
+);
+filterButtons.forEach(btn => btn.addEventListener('click', () => {
+  filterButtons.forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  currentFilter = btn.dataset.filter;
+  renderTasks();
+}));
+searchInput.addEventListener('input', e => {
+  searchText = e.target.value.toLowerCase();
+  renderTasks();
+});
+sortSelect.addEventListener('change', e => {
+  sortBy = e.target.value;
+  renderTasks();
+});
+undoButton.addEventListener('click', undo);
+clearButton.addEventListener('click', clearAll);
+document.addEventListener('keydown', e => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 'z') undo();
+});
+
+initTheme();
+renderTasks();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,113 @@
+/* style.css - Estilos modernos para la lista de tareas */
+:root {
+  --bg-color: #f4f4f4;
+  --text-color: #333;
+  --accent-color: #1976d2;
+}
+
+/* Modo oscuro */
+.dark {
+  --bg-color: #222;
+  --text-color: #eee;
+  --accent-color: #90caf9;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+  transition: background 0.3s, color 0.3s;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1em;
+  background: var(--accent-color);
+  color: white;
+}
+
+.controls {
+  padding: 1em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+}
+
+.new-task {
+  flex: 1;
+  display: flex;
+}
+
+.new-task input,
+.new-task select {
+  flex: 1;
+  margin-right: 0.5em;
+}
+
+.task-list {
+  list-style: none;
+  padding: 0;
+  margin: 1em;
+}
+
+.task-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(0,0,0,0.05);
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  border-radius: 4px;
+  transition: background 0.3s;
+}
+
+.task-list li.completed {
+  text-decoration: line-through;
+  color: gray;
+  background: rgba(0,0,0,0.1);
+}
+.task-list li.overdue {
+  background: #ffcccc;
+}
+.task-list li.due-soon {
+  background: #fff3cd;
+}
+.task-list li.on-time {
+  background: #e6ffe6;
+}
+
+.task-list li .info {
+  flex: 1;
+}
+
+.task-list button {
+  margin-left: 0.25em;
+}
+
+.filters button.active {
+  font-weight: bold;
+}
+
+@media (max-width: 600px) {
+  .new-task {
+    flex-direction: column;
+  }
+  .new-task input {
+    margin-right: 0;
+    margin-bottom: 0.5em;
+  }
+  .new-task select {
+    margin-right: 0;
+    margin-bottom: 0.5em;
+  }
+}
+
+.charts {
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+  margin: 1em;
+}

--- a/todo.html
+++ b/todo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Lista de Tareas Avanzada</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="header">
+    <h1>Lista de Tareas</h1>
+    <button id="themeToggle" aria-label="Alternar modo claro/oscuro">🌗</button>
+  </header>
+
+  <section class="controls">
+    <input type="text" id="searchInput" placeholder="Buscar...">
+    <div class="new-task">
+      <input type="text" id="taskInput" placeholder="Nueva tarea">
+      <input type="text" id="categoryInput" placeholder="Categoría">
+      <input type="text" id="responsibleInput" placeholder="Responsable">
+      <select id="importanceInput">
+        <option value="Alta">Alta</option>
+        <option value="Media">Media</option>
+        <option value="Baja">Baja</option>
+      </select>
+      <select id="priorityInput">
+        <option value="Alta">Alta</option>
+        <option value="Media">Media</option>
+        <option value="Baja">Baja</option>
+      </select>
+      <input type="date" id="dueDateInput">
+      <button id="addButton">Agregar</button>
+    </div>
+    <div class="filters">
+      <button data-filter="all" class="filter active">Todas</button>
+      <button data-filter="pending" class="filter">Pendientes</button>
+      <button data-filter="completed" class="filter">Completadas</button>
+    </div>
+    <div class="sorting">
+      <label for="sortSelect">Ordenar:</label>
+      <select id="sortSelect">
+        <option value="date">Fecha</option>
+        <option value="name">Nombre</option>
+        <option value="status">Estado</option>
+      </select>
+    </div>
+    <div class="actions">
+      <button id="undoButton">Deshacer</button>
+      <button id="clearButton">Eliminar Todo</button>
+    </div>
+  </section>
+
+  <section class="counters">
+    <span id="totalCount">0 totales</span> |
+    <span id="completedCount">0 completadas</span> |
+    <span id="pendingCount">0 pendientes</span>
+  </section>
+
+  <ul id="taskList" class="task-list"></ul>
+
+  <section class="charts">
+    <canvas id="statusChart" width="200" height="200"></canvas>
+    <canvas id="priorityChart" width="200" height="200"></canvas>
+  </section>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add closedAt field to tasks when completed to track closing date
- show closing date in the task list when available
- persist closedAt in undo/redo logic
- document new feature in README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_683f6c52c7e4832d92cc7d6463aa5132